### PR TITLE
fixed tests for HTTP_REFERER

### DIFF
--- a/landing_map/views.py
+++ b/landing_map/views.py
@@ -116,7 +116,6 @@ def index(request):
         "favorited": favorited,
         "hideSearchBar": favPage,
         "loggedIn": loggedIn,
-       
     }
     return render(request, "landing_map/home.html", context)
 


### PR DESCRIPTION
https://stackoverflow.com/questions/62057138/setting-httpreferrer-in-unit-tests
https://adiyatmubarak.wordpress.com/tag/http-referer-in-django-test-client/
based solution off of these two pages -- basically because of how the test client processes the requests, there was no referrer, so i had to specify one